### PR TITLE
Added Basic Authentication against camunda process engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>gson</artifactId>
             <version>2.8.0</version>
         </dependency>
+	    <dependency>
+	          <groupId>javax.ws.rs</groupId>
+	          <artifactId>javax.ws.rs-api</artifactId>
+	          <version>2.0.1</version>
+	    </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/camunda/bpm/extension/graphql/FilterConfiguration.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/FilterConfiguration.java
@@ -1,0 +1,29 @@
+package org.camunda.bpm.extension.graphql;
+
+import javax.servlet.Filter;
+
+import org.camunda.bpm.extension.graphql.auth.ProcessEngineAuthenticationFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfiguration {
+
+	 @Bean
+	    public FilterRegistrationBean someFilterRegistration() {
+
+	        FilterRegistrationBean registration = new FilterRegistrationBean();
+	        registration.setFilter(GraphqlAuth());
+	        registration.addUrlPatterns("/*");
+	        registration.addInitParameter("authentication-provider", "org.camunda.bpm.extension.graphql.auth.impl.HttpBasicAuthenticationProvider");
+	        registration.setName("camunda-auth");
+	        registration.setOrder(1);
+	        return registration;
+	    } 
+
+	    @Bean(name = "GraphqlAuth")
+	    public Filter GraphqlAuth() {
+	        return new ProcessEngineAuthenticationFilter();
+	    }
+}

--- a/src/main/java/org/camunda/bpm/extension/graphql/auth/AuthenticationProvider.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/auth/AuthenticationProvider.java
@@ -1,0 +1,51 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.extension.graphql.auth;
+
+import org.camunda.bpm.engine.ProcessEngine;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A provider to handle the authentication of {@link HttpServletRequest}s.
+ * May implement a specific authentication scheme.
+ *
+ * @author Thorben Lindhauer
+ */
+public interface AuthenticationProvider {
+
+  /**
+   * Checks the request for authentication. May not return null, but always an {@link AuthenticationResult} that indicates, whether
+   * authentication was successful, and, if true, always provides the authenticated user.
+   *
+   * @param request the request to authenticate
+   * @param engine the process engine the request addresses. May be used to authenticate against the engine's identity service.
+   */
+  AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine);
+
+  /**
+   * <p>
+   * Callback to add an authentication challenge to the response to the client. Called in case of unsuccessful authentication.
+   * </p>
+   *
+   * <p>
+   * For example, a Http Basic auth implementation may set the WWW-Authenticate header to <code>Basic realm="engine name"</code>.
+   * </p>
+   *
+   * @param request the response to augment
+   * @param engine the process engine the request addressed. May be considered as an authentication realm to create a specific authentication
+   * challenge
+   */
+  void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine);
+}

--- a/src/main/java/org/camunda/bpm/extension/graphql/auth/AuthenticationResult.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/auth/AuthenticationResult.java
@@ -1,0 +1,49 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.extension.graphql.auth;
+
+public class AuthenticationResult {
+
+  protected String authenticatedUser;
+  protected boolean isAuthenticated;
+
+  public AuthenticationResult(String authenticatedUser, boolean isAuthenticated) {
+    this.authenticatedUser = authenticatedUser;
+    this.isAuthenticated = isAuthenticated;
+  }
+
+  public String getAuthenticatedUser() {
+    return authenticatedUser;
+  }
+  public void setAuthenticatedUser(String authenticatedUser) {
+    this.authenticatedUser = authenticatedUser;
+  }
+  public boolean isAuthenticated() {
+    return isAuthenticated;
+  }
+  public void setAuthenticated(boolean isAuthenticated) {
+    this.isAuthenticated = isAuthenticated;
+  }
+
+  public static AuthenticationResult successful(String userId) {
+    return new AuthenticationResult(userId, true);
+  }
+
+  public static AuthenticationResult unsuccessful() {
+    return new AuthenticationResult(null, false);
+  }
+
+  public static AuthenticationResult unsuccessful(String userId) {
+    return new AuthenticationResult(userId, false);
+  }
+}

--- a/src/main/java/org/camunda/bpm/extension/graphql/auth/ProcessEngineAuthenticationFilter.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/auth/ProcessEngineAuthenticationFilter.java
@@ -1,0 +1,183 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.extension.graphql.auth;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+
+import org.camunda.bpm.BpmPlatform;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngines;
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.Tenant;
+
+import org.camunda.bpm.extension.graphql.auth.AuthenticationProvider;
+import org.camunda.bpm.extension.graphql.auth.AuthenticationResult;
+
+//import org.camunda.bpm.engine.rest.dto.ExceptionDto;
+//import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+//import org.camunda.bpm.engine.rest.impl.NamedProcessEngineRestServiceImpl;
+//import org.camunda.bpm.engine.rest.util.EngineUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * <p>
+ * Servlet filter to plug in authentication.
+ * </p>
+ *
+ * <p>Valid init-params:</p>
+ * <table>
+ * <thead>
+ *   <tr><th>Parameter</th><th>Required</th><th>Expected value</th></tr>
+ * <thead>
+ * <tbody>
+ *    <tr><td>{@value #AUTHENTICATION_PROVIDER_PARAM}</td><td>yes</td><td>An implementation of {@link AuthenticationProvider}</td></tr>
+ *    <tr>
+ *      <td>{@value #SERVLET_PATH_PREFIX}</td>
+ *      <td>no</td>
+ *      <td>The expected servlet path. Should only be set, if the underlying JAX-RS application is not deployed as a servlet (e.g. Resteasy allows deployments
+ *      as a servlet filter). Value has to match what would be the {@link HttpServletRequest#getServletPath()} if it was deployed as a servlet.</td></tr>
+ * </tbody>
+ * </table>
+ *
+ * @author Thorben Lindhauer
+ */
+public class ProcessEngineAuthenticationFilter implements Filter {
+
+
+  // init params
+  public static final String AUTHENTICATION_PROVIDER_PARAM = "authentication-provider";
+
+  protected AuthenticationProvider authenticationProvider;
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    String authenticationProviderClassName = filterConfig.getInitParameter(AUTHENTICATION_PROVIDER_PARAM);
+
+    if (authenticationProviderClassName == null) {
+      throw new ServletException("Cannot instantiate authentication filter: no authentication provider set. init-param " + AUTHENTICATION_PROVIDER_PARAM + " missing");
+    }
+
+    try {
+      Class<?> authenticationProviderClass = Class.forName(authenticationProviderClassName);
+      authenticationProvider = (AuthenticationProvider) authenticationProviderClass.newInstance();
+    } catch (ClassNotFoundException e) {
+      throw new ServletException("Cannot instantiate authentication filter: authentication provider not found", e);
+    } catch (InstantiationException e) {
+      throw new ServletException("Cannot instantiate authentication filter: cannot instantiate authentication provider", e);
+    } catch (IllegalAccessException e) {
+      throw new ServletException("Cannot instantiate authentication filter: constructor not accessible", e);
+    } catch (ClassCastException e) {
+      throw new ServletException("Cannot instantiate authentication filter: authentication provider does not implement interface " +
+          AuthenticationProvider.class.getName(), e);
+    }
+
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response,
+      FilterChain chain) throws IOException, ServletException {
+
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse resp = (HttpServletResponse) response;
+
+   
+    ProcessEngine engine = BpmPlatform.getDefaultProcessEngine();
+    
+    if (engine == null) {
+    	engine = ProcessEngines.getDefaultProcessEngine(false);
+    }
+
+    if (engine == null) {
+      resp.setStatus(Status.NOT_FOUND.getStatusCode());
+      String errMessage = "Default Process engine not available";
+      ObjectMapper objectMapper = new ObjectMapper();
+
+      resp.setContentType(MediaType.APPLICATION_JSON);
+      objectMapper.writer().writeValue(resp.getWriter(), errMessage);
+      resp.getWriter().flush();
+
+      return;
+    }
+
+    AuthenticationResult authenticationResult = authenticationProvider.extractAuthenticatedUser(req, engine);
+
+    if (authenticationResult.isAuthenticated()) {
+      try {
+        setAuthenticatedUser(engine, authenticationResult.getAuthenticatedUser());
+        chain.doFilter(request, response);
+      } finally {
+        clearAuthentication(engine);
+      }
+    } else {
+      resp.setStatus(Status.UNAUTHORIZED.getStatusCode());
+      authenticationProvider.augmentResponseByAuthenticationChallenge(resp, engine);
+    }
+
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+  protected void setAuthenticatedUser(ProcessEngine engine, String userId) {
+    List<String> groupIds = getGroupsOfUser(engine, userId);
+    List<String> tenantIds = getTenantsOfUser(engine, userId);
+
+    engine.getIdentityService().setAuthentication(userId, groupIds, tenantIds);
+  }
+
+  protected List<String> getGroupsOfUser(ProcessEngine engine, String userId) {
+    List<Group> groups = engine.getIdentityService().createGroupQuery()
+      .groupMember(userId)
+      .list();
+
+    List<String> groupIds = new ArrayList<String>();
+    for (Group group : groups) {
+      groupIds.add(group.getId());
+    }
+    return groupIds;
+  }
+
+  protected List<String> getTenantsOfUser(ProcessEngine engine, String userId) {
+    List<Tenant> tenants = engine.getIdentityService().createTenantQuery()
+      .userMember(userId)
+      .includingGroupsOfUser(true)
+      .list();
+
+    List<String> tenantIds = new ArrayList<String>();
+    for(Tenant tenant : tenants) {
+      tenantIds.add(tenant.getId());
+    }
+    return tenantIds;
+  }
+
+  protected void clearAuthentication(ProcessEngine engine) {
+    engine.getIdentityService().clearAuthentication();
+  }
+
+}

--- a/src/main/java/org/camunda/bpm/extension/graphql/auth/impl/HttpBasicAuthenticationProvider.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/auth/impl/HttpBasicAuthenticationProvider.java
@@ -1,0 +1,70 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.extension.graphql.auth.impl;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.digest._apacheCommonsCodec.Base64;
+import org.camunda.bpm.extension.graphql.auth.AuthenticationProvider;
+import org.camunda.bpm.extension.graphql.auth.AuthenticationResult;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+/**
+ * <p>
+ * Authenticates a request against the provided process engine's identity service by applying http basic authentication.
+ * </p>
+ *
+ * @author Thorben Lindhauer
+ */
+public class HttpBasicAuthenticationProvider implements AuthenticationProvider {
+
+  protected static final String BASIC_AUTH_HEADER_PREFIX = "Basic ";
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request,
+      ProcessEngine engine) {
+    String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (authorizationHeader != null && authorizationHeader.startsWith(BASIC_AUTH_HEADER_PREFIX)) {
+      String encodedCredentials = authorizationHeader.substring(BASIC_AUTH_HEADER_PREFIX.length());
+      String decodedCredentials = new String(Base64.decodeBase64(encodedCredentials));
+      int firstColonIndex = decodedCredentials.indexOf(":");
+
+      if (firstColonIndex == -1) {
+        return AuthenticationResult.unsuccessful();
+      } else {
+        String userName = decodedCredentials.substring(0, firstColonIndex);
+        String password = decodedCredentials.substring(firstColonIndex + 1);
+        if (isAuthenticated(engine, userName, password)) {
+          return AuthenticationResult.successful(userName);
+        } else {
+          return AuthenticationResult.unsuccessful(userName);
+        }
+      }
+    } else {
+      return AuthenticationResult.unsuccessful();
+    }
+  }
+
+  protected boolean isAuthenticated(ProcessEngine engine, String userName, String password) {
+    return engine.getIdentityService().checkPassword(userName, password);
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(
+      HttpServletResponse response, ProcessEngine engine) {
+    response.setHeader(HttpHeaders.WWW_AUTHENTICATE, BASIC_AUTH_HEADER_PREFIX + "realm=\"" + engine.getName() + "\"");
+  }
+}


### PR DESCRIPTION
Added Basic Authentication Filter that authenticates the user with the camunda process engine. Other filter implementations can be added as required under auth/impl. This reuses the camunda-rest authentication implementation.