### PR TITLE
Update graphql-java-tools and allow querying process instance variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,10 @@
             <artifactId>json-path</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.coxautodev</groupId>
+       <dependency>
+            <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-tools</artifactId>
-            <version>1.0.0</version>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>

--- a/src/main/java/org/camunda/bpm/extension/graphql/GraphQLServer.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/GraphQLServer.java
@@ -37,7 +37,7 @@ public class GraphQLServer extends SpringBootServletInitializer {
     }
 
     @Autowired
-    private List<GraphQLResolver> resolvers;
+    private List<GraphQLResolver<?>> resolvers;
 
     @Bean
     public GraphQLSchema graphQLSchema() {

--- a/src/main/java/org/camunda/bpm/extension/graphql/resolvers/ExecutionEntityResolver.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/resolvers/ExecutionEntityResolver.java
@@ -1,0 +1,66 @@
+package org.camunda.bpm.extension.graphql.resolvers;
+
+import com.coxautodev.graphql.tools.GraphQLResolver;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.camunda.bpm.BpmPlatform;
+import org.camunda.bpm.engine.*;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.springframework.stereotype.Component;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.engine.variable.value.FileValue;
+import org.camunda.bpm.engine.variable.value.SerializableValue;
+import org.camunda.bpm.engine.variable.value.TypedValue;
+
+@Component
+public class ExecutionEntityResolver implements GraphQLResolver<ExecutionEntity> {
+
+    private ProcessEngine pe;
+
+    private TaskService taskService;
+    private RuntimeService runtimeService;
+
+    public ExecutionEntityResolver() {
+    	 pe = BpmPlatform.getDefaultProcessEngine();
+         if(pe == null) {
+             pe = ProcessEngines.getDefaultProcessEngine(false);
+         }
+         taskService = pe.getTaskService();
+         runtimeService = pe.getRuntimeService();
+    }
+
+    public List<KeyValuePair> variables(ProcessInstance pi) {
+        
+        ArrayList<KeyValuePair> kvps = new ArrayList<KeyValuePair>();
+        
+        VariableMap variables = null;
+		variables = runtimeService.getVariablesTyped(pi.getId());
+		
+		for(String name: variables.keySet()) {
+			KeyValuePair kvp = new KeyValuePair();
+			String type;
+			
+		     kvp.setKey(name);
+		     
+		     TypedValue variable = variables.getValueTyped(name);
+		     
+		     type = variable.getType().getName();
+		     if (type != null) {
+		    	 kvp.setValueType(type.substring(0, 1).toUpperCase() + type.substring(1));
+		     }
+		     
+		     kvp.setValue(variable.getValue().toString());
+		     
+		     kvps.add(kvp);
+		    }
+		
+        return kvps;
+    }
+}

--- a/src/main/java/org/camunda/bpm/extension/graphql/resolvers/KeyValuePairInput.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/resolvers/KeyValuePairInput.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 //@todo: implement next
 @Component
-public class KeyValuePair {
+public class KeyValuePairInput {
 
     private String key = null;
     private String value = null;

--- a/src/main/java/org/camunda/bpm/extension/graphql/resolvers/Mutation.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/resolvers/Mutation.java
@@ -16,7 +16,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class Mutation extends GraphQLRootResolver {
+public class Mutation implements GraphQLRootResolver {
 
     private ProcessEngine pe;
     private TaskService taskService;

--- a/src/main/java/org/camunda/bpm/extension/graphql/resolvers/Query.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/resolvers/Query.java
@@ -7,6 +7,7 @@ import org.camunda.bpm.engine.ProcessEngines;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.task.TaskQuery;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class Query extends GraphQLRootResolver {
+public class Query implements GraphQLRootResolver {
 
     private ProcessEngine pe;
 
@@ -49,8 +50,10 @@ public class Query extends GraphQLRootResolver {
         return task;
     }
 
-    public List<ProcessInstance> processesInstances() {
-        List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery().list();
+    public List<ProcessInstance> processesInstances(String businessKey) {
+    	ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery();
+    	processInstanceQuery = (businessKey != null) ? processInstanceQuery.processInstanceBusinessKey(businessKey):processInstanceQuery;
+        List<ProcessInstance> processInstances = processInstanceQuery.list();
         return processInstances;
     }
 }

--- a/src/main/java/org/camunda/bpm/extension/graphql/resolvers/TaskEntityResolver.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/resolvers/TaskEntityResolver.java
@@ -12,7 +12,7 @@ import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TaskEntityResolver extends GraphQLResolver {
+public class TaskEntityResolver implements GraphQLResolver<TaskEntity> {
 
     private ProcessEngine pe;
     private RepositoryService repositoryService;
@@ -20,7 +20,7 @@ public class TaskEntityResolver extends GraphQLResolver {
     private IdentityService identityService;
 
     public TaskEntityResolver() {
-        super(TaskEntity.class);
+        //super(TaskEntity.class);
         pe = BpmPlatform.getDefaultProcessEngine();
         if (pe == null) {
             pe = ProcessEngines.getDefaultProcessEngine(false);

--- a/src/main/resources/Execution.graphqls
+++ b/src/main/resources/Execution.graphqls
@@ -6,8 +6,10 @@ interface ProcessInstance @doc(d: "Represents one execution of a ProcessDefiniti
     isEnded: Boolean
     processDefinitionId: String
     businessKey: String
-    CaseInstanceId: String
+    caseInstanceId: String
+    variables: [KeyValuePair]
 }
+
 
 type ExecutionEntity implements ProcessInstance {
     id: String
@@ -16,17 +18,6 @@ type ExecutionEntity implements ProcessInstance {
     isEnded: Boolean
     processDefinitionId: String
     businessKey: String
-    CaseInstanceId: String
-}
-
-type ProcessInstanceWithVariablesImpl implements ProcessInstance {
-    id: String
-    processInstanceId: String
-    tenantId: String
-    isEnded: Boolean
-    processDefinitionId: String
-    businessKey: String
-    CaseInstanceId: String
-
-    variables: String
+    caseInstanceId: String
+    variables: [KeyValuePair]
 }

--- a/src/main/resources/camunda.graphqls
+++ b/src/main/resources/camunda.graphqls
@@ -8,11 +8,14 @@ type Query {
     : [Task]
     @doc(d: "Allows programmatic querying of Tasks based on the public Interface org.camunda.bpm.engine.task.TaskQuery")
 
-    task(
-        id: String!
-    ): Task
-
-    processesInstances: [ProcessInstance]
+	task(
+		id: String!
+	): Task
+ 
+    processesInstances(
+    	businessKey: String @doc(d: "Only select process instances with a certain business key.")
+   	): [ProcessInstance]
+   	
 }
 
 type Mutation {
@@ -30,8 +33,8 @@ type Mutation {
     @doc(d: "Starts a new process instance in the latest version of the process definition with the given key.")
 
     completeTask(
-        taskId: String!
-        variables: [KeyValuePair]!
+        taskId: String! 
+    	variables: [KeyValuePairInput]!    
     )
     : ProcessInstance
     @doc(d: "Marks a task as done and continues process execution. This method is typically called by a task list user interface after a task form has been submitted by the assignee and the required task parameters have been provided.")
@@ -44,9 +47,16 @@ type Mutation {
     @doc(d: "Claim responsibility for a task: the given user is made assignee for the task. The difference with setAssignee(String, String) is that here a check is done if the task already has a user assigned to it. No check is done whether the user is known by the identity component.")
 }
 
-input KeyValuePair {
+type KeyValuePair {
     key: String!
     value: String!
+    valueType: String
+}
+
+input KeyValuePairInput {
+    key: String!
+    value: String!
+    valueType: String
 }
 
 


### PR DESCRIPTION
Hi Guys,

I'll preface this by saying I haven't done much graphql but this plugin is going to prove useful to me in getting around some of the performance limitations when using the camunda rest api in an app my company is building. Let me know if there are better ways of doing anything I open a pull request for.

This request -

I've Updated to use the latest graphql-java-tools. 

I've also updated process instance querying to also get variables back. Format is Key, Value, ValueType (all strings). Based on the camunda rest web services.

{processesInstances{
  id
  variables {
    key
    value
    valueType
  }
}}

The mutation to add task variables on complete has been changed a little but is currently untested. It seems the input type and data type from the graphql schema can't be the same name? Hence KeyValuePair and KeyValuePairInput classes. Though I may be missing something?

cheers
Mark

