### PR TITLE
Camunda BPM 7.12 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.camunda</groupId>
         <artifactId>camunda-release-parent</artifactId>
-        <version>2.5</version>
+        <version>3.7</version>
         <!-- DO NOT REMOVE EMPTY TAG https://issues.apache.org/jira/browse/MNG-4687 -->
         <relativePath />
     </parent>
@@ -18,10 +18,10 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-boot.version>1.5.7.RELEASE</spring-boot.version>
-        <camunda.version>7.7.0</camunda.version>
-        <h2.version>1.4.193</h2.version>
-        <spin.version>1.3.1</spin.version>
+        <spring-boot.version>2.2.1.RELEASE</spring-boot.version>
+        <camunda.version>7.12.0</camunda.version>
+        <h2.version>1.4.200</h2.version>
+        <spin.version>1.8.0</spin.version>
 
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <!-- disable javadoc linter for JDK8 to not fail on incomplete javadoc -->
@@ -72,27 +72,29 @@
             <scope>test</scope>
         </dependency>
        <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-java-tools</artifactId>
-            <version>4.1.2</version>
+            <version>5.7.1</version>
         </dependency>
         <!-- GraphQL spring-boot -->
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphql-spring-boot-starter</artifactId>
-            <version>3.9.2</version>
+            <version>6.0.1</version>
         </dependency>
         <!-- to embed GraphiQL tool -->
+        <!--
         <dependency>
-            <groupId>com.graphql-java</groupId>
+            <groupId>com.graphql-java-kickstart</groupId>
             <artifactId>graphiql-spring-boot-starter</artifactId>
-            <version>3.9.2</version>
+            <version>6.0.1</version>
         </dependency>
+        -->
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>
@@ -103,12 +105,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.6</version>
         </dependency>
   	    <dependency>
   	          <groupId>javax.ws.rs</groupId>
   	          <artifactId>javax.ws.rs-api</artifactId>
-  	          <version>2.0.1</version>
+  	          <version>2.1.1</version>
   	    </dependency>
         <dependency>
           <groupId>org.camunda.bpm</groupId>
@@ -118,7 +120,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.2.0</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.camunda.spin</groupId>
@@ -138,7 +140,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>4.3.9.RELEASE</version>
+            <version>5.2.3.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -147,9 +149,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.camunda.bpm.extension</groupId>
+            <groupId>org.camunda.bpm.assert</groupId>
             <artifactId>camunda-bpm-assert</artifactId>
-            <version>1.2</version>
+            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
         <!-- use in-memory database in component/integration tests -->
@@ -179,6 +181,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
                 <configuration>
                     <rules>
                         <requireJavaVersion>
@@ -193,6 +196,27 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.1</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.apache.maven.surefire</groupId>
+                  <artifactId>surefire-junit47</artifactId>
+                  <version>2.22.1</version>
+                </dependency>
+              </dependencies>
+              <configuration>
+                <includes>
+                  <include>**/*Tests.java</include>
+                  <include>**/*Test.java</include>
+                </includes>
+                <excludes>
+                  <exclude>**/Abstract*.java</exclude>
+                </excludes>
+              </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>

--- a/src/main/java/org/camunda/bpm/extension/graphql/GraphQLServer.java
+++ b/src/main/java/org/camunda/bpm/extension/graphql/GraphQLServer.java
@@ -3,7 +3,7 @@ package org.camunda.bpm.extension.graphql;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
 public class GraphQLServer extends SpringBootServletInitializer {

--- a/src/test/java/org/camunda/bpm/extension/graphql/GraphQLTest.java
+++ b/src/test/java/org/camunda/bpm/extension/graphql/GraphQLTest.java
@@ -4,10 +4,8 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.schema.GraphQLSchema;
 import org.camunda.bpm.engine.RuntimeService;
-import org.camunda.bpm.engine.impl.util.json.JSONObject;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
-import org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,10 +14,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.processDefinition;
 import static org.camunda.spin.Spin.JSON;
 import static org.mockito.Mockito.when;
@@ -50,7 +53,7 @@ public class GraphQLTest {
         when(customerDataServiceMock.findById(EXAMPLE_ID)).thenReturn(customer);
 
         processInstance = runtimeService.startProcessInstanceByKey(PROCESS_KEY, BUSINESS_KEY, startFormEntries(450000));
-        ProcessEngineAssertions.assertThat(processInstance).isNotEnded();
+        assertThat(processInstance).isNotEnded();
 
         graphQL = GraphQL.newGraphQL(graphQLSchema).build();
     }
@@ -80,8 +83,8 @@ public class GraphQLTest {
         assertThat(map.keySet().toArray()[0]).as("name of first key").isEqualTo("processInstances");
 
         String actualResult = JSON(map).toString();
-        JSONObject obj = new JSONObject(actualResult);
-        String idString = obj.getJSONArray("processInstances").getJSONObject(0).getString("id");
+        JsonObject obj = new JsonParser().parse(actualResult).getAsJsonObject();
+        String idString = obj.get("processInstances").getAsJsonArray().get(0).getAsJsonObject().get("id").getAsString();
         Integer id = Integer.parseInt(idString);
         assertThat(id).as("processInstanceId").isGreaterThan(0);
     }
@@ -122,8 +125,8 @@ public class GraphQLTest {
         HashMap<String,Object> map = (HashMap<String,Object>)(executionResult.getData());
         String actualResult = JSON(map).toString();
 
-        JSONObject obj = new JSONObject(actualResult);
-        String id = obj.getJSONArray("tasks").getJSONObject(0).getString("id");
+        JsonObject obj = new JsonParser().parse(actualResult).getAsJsonObject();
+        String id = obj.get("tasks").getAsJsonArray().get(0).getAsJsonObject().get("id").getAsString();
 
         final String query = "mutation {\n" +
                 "  claimTask(taskId: \"" + id + "\", userId:\"demo\") {\n" +

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,5 @@
+spring.main.allow-bean-definition-overriding=true
+
 graphql.servlet.mapping=/graphql
 graphql.servlet.enabled=true
 graphql.servlet.corsEnabled=true


### PR DESCRIPTION
Tried to figure out mostly minimal changes required for compatibility with the recent releases.

Tests pass.

graphiql is disable, because it seems to need additional work, but I don't need it myself.

[mvn-clean-test.log](https://github.com/camunda/camunda-bpm-graphql/files/4129684/mvn-clean-test.log)